### PR TITLE
Expose `mfp` binary through npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,7 @@ Stream musicforprogramming.net directly in your terminal!
 
 ## Installing
 ```bash
-cd /opt
-mkdir mfp
-cd mfp
 npm install -g music-for-programming
-cd node_modules/music-for-programming
-chmod +x mfp.js
-sudo ln -s /opt/mfp/node_modules/music-for-programming/mfp.js /usr/local/bin/mfp
 ```
 
 ## Running

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "music-for-programming",
   "version": "0.1.1",
   "description": "Stream musicForProgramming.net directly into your terminal window",
+  "bin": {
+    "mfp": "mfp.js"
+  },
   "main": "mfp.js",
   "dependencies": {
     "blessed": "^0.1.81",


### PR DESCRIPTION
This allows users to just `npm install -g music-for-programming` and enjoy the `mfp` command without any other install dance 💃☺
